### PR TITLE
添加缺失的八股文相关文件

### DIFF
--- a/配置文件/grammar.custom.yaml
+++ b/配置文件/grammar.custom.yaml
@@ -1,0 +1,34 @@
+# patch:
+#   __include: hant
+
+hant:
+  grammar:
+    language: zh-hant-t-essay-bgw
+  translator/contextual_suggestions: true
+  translator/max_homophones: 7
+  translator/max_homographs: 7
+
+hans:
+  grammar:
+    language: zh-hans-t-essay-bgw
+  translator/contextual_suggestions: true
+  translator/max_homophones: 7
+  translator/max_homographs: 7
+
+hant_char:
+  grammar:
+    language: zh-hant-t-essay-bgc
+    collocation_max_length: 2
+    collocation_min_length: 2
+  translator/contextual_suggestions: true
+  translator/max_homophones: 7
+  translator/max_homographs: 7
+
+hans_char:
+  grammar:
+    language: zh-hans-t-essay-bgc
+    collocation_max_length: 2
+    collocation_min_length: 2
+  translator/contextual_suggestions: true
+  translator/max_homophones: 7
+  translator/max_homographs: 7

--- a/配置文件/grammar.yaml
+++ b/配置文件/grammar.yaml
@@ -1,0 +1,34 @@
+# patch:
+#   __include: hant
+
+hant:
+  grammar:
+    language: zh-hant-t-essay-bgw
+  translator/contextual_suggestions: true
+  translator/max_homophones: 7
+  translator/max_homographs: 7
+
+hans:
+  grammar:
+    language: zh-hans-t-essay-bgw
+  translator/contextual_suggestions: true
+  translator/max_homophones: 7
+  translator/max_homographs: 7
+
+hant_char:
+  grammar:
+    language: zh-hant-t-essay-bgc
+    collocation_max_length: 2
+    collocation_min_length: 2
+  translator/contextual_suggestions: true
+  translator/max_homophones: 7
+  translator/max_homographs: 7
+
+hans_char:
+  grammar:
+    language: zh-hans-t-essay-bgc
+    collocation_max_length: 2
+    collocation_min_length: 2
+  translator/contextual_suggestions: true
+  translator/max_homophones: 7
+  translator/max_homographs: 7


### PR DESCRIPTION
https://github.com/ssnhd/rime/blob/36b00c20dcb825b97e86f976cb1363a8f8461dab/%E9%85%8D%E7%BD%AE%E6%96%87%E4%BB%B6/double_pinyin_flypy.custom.yaml#L96
https://github.com/ssnhd/rime/blob/36b00c20dcb825b97e86f976cb1363a8f8461dab/%E9%85%8D%E7%BD%AE%E6%96%87%E4%BB%B6/double_pinyin.custom.yaml#L99
小鹤双拼鹤自然码双拼的配置里都引用了八股文的配置，但由于八股文配置缺失，`double_pinyin_flypy.custom.yaml`和`double_pinyin.custom.yaml`两个文件都没有生效，例如emoji相关的配置不显示。